### PR TITLE
Switch to redis for caching

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,9 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
+# Use redis as cache
+gem 'redis', '~>3.2'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'


### PR DESCRIPTION
For performance reasons we decided to use Redis for chaching. This PR implements the changes necessary for the switch.